### PR TITLE
CON-124 feat: Add POST /search endpoint for advanced boundary and proximity filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+.tool-versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@swc/cli": "^0.4.0",
         "@swc/core": "^1.13.3",
         "@types/express": "^4.17.25",
+        "@types/geojson": "^7946.0.16",
         "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.10.9",
@@ -2770,6 +2771,13 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@swc/core": "^1.13.3",
     "@types/express": "^4.17.25",
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/geojson": "^7946.0.16",
     "@types/jest": "^29.5.14",
     "@types/node": "^24.10.9",
     "@types/supertest": "^6.0.3",

--- a/src/common/middleware/TenantMiddleware.ts
+++ b/src/common/middleware/TenantMiddleware.ts
@@ -11,7 +11,6 @@ import { Cache } from 'cache-manager';
 import { Request, Response, NextFunction } from 'express';
 import { xTenantIdSchema } from '../dto/headers.dto';
 import { fetchTenantById } from '../lib/utils';
-import * as z from 'zod';
 
 @Injectable()
 export class TenantMiddleware implements NestMiddleware {
@@ -29,7 +28,7 @@ export class TenantMiddleware implements NestMiddleware {
 
     const validation = xTenantIdSchema.safeParse(rawHeader);
     if (!validation.success) {
-      const flattened = z.flattenError(validation.error);
+      const flattened = validation.error.flatten();
       this.logger.warn(`Invalid Tenant Header: ${JSON.stringify(flattened)}`);
       throw new BadRequestException('Missing or invalid x-tenant-id header.');
     }

--- a/src/search/dto/search-body.dto.ts
+++ b/src/search/dto/search-body.dto.ts
@@ -1,7 +1,48 @@
 import { z } from 'zod';
 
+const positionSchema = z.number().array().min(2);
+
+const pointSchema = z.object({
+  type: z.literal('Point'),
+  coordinates: positionSchema,
+});
+
+const multiPointSchema = z.object({
+  type: z.literal('MultiPoint'),
+  coordinates: z.array(positionSchema),
+});
+
+const lineStringSchema = z.object({
+  type: z.literal('LineString'),
+  coordinates: z.array(positionSchema),
+});
+
+const multiLineStringSchema = z.object({
+  type: z.literal('MultiLineString'),
+  coordinates: z.array(z.array(positionSchema)),
+});
+
+const polygonSchema = z.object({
+  type: z.literal('Polygon'),
+  coordinates: z.array(z.array(positionSchema)),
+});
+
+const multiPolygonSchema = z.object({
+  type: z.literal('MultiPolygon'),
+  coordinates: z.array(z.array(z.array(positionSchema))),
+});
+
+const geometrySchema = z.union([
+  pointSchema,
+  multiPointSchema,
+  lineStringSchema,
+  multiLineStringSchema,
+  polygonSchema,
+  multiPolygonSchema,
+]);
+
 export const searchBodySchema = z.object({
-  geometry: z.any().optional(),
+  geometry: geometrySchema.optional(),
 });
 
 export type SearchBodyDto = z.infer<typeof searchBodySchema>;

--- a/src/search/dto/search-body.dto.ts
+++ b/src/search/dto/search-body.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const searchBodySchema = z.object({
+  geometry: z.any().optional(),
+});
+
+export type SearchBodyDto = z.infer<typeof searchBodySchema>;

--- a/src/search/dto/search-body.dto.ts
+++ b/src/search/dto/search-body.dto.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
-const positionSchema = z.number().array().min(2);
+// GeoJSON spec requires at least 2 numbers (lon, lat), optionally 3 (altitude).
+const positionSchema = z.number().array().min(2).max(3);
 
 const pointSchema = z.object({
   type: z.literal('Point'),
@@ -32,7 +33,9 @@ const multiPolygonSchema = z.object({
   coordinates: z.array(z.array(z.array(positionSchema))),
 });
 
-const geometrySchema = z.union([
+// Discriminated union tells Zod to use the 'type' field to
+// switch between schemas efficiently.
+const geometrySchema = z.discriminatedUnion('type', [
   pointSchema,
   multiPointSchema,
   lineStringSchema,

--- a/src/search/dto/search-query.dto.ts
+++ b/src/search/dto/search-query.dto.ts
@@ -43,6 +43,7 @@ export const searchQuerySchema = z.object({
   filters: z.record(z.string(), z.string().or(z.array(z.string()))).default({}),
   distance: z.coerce.number().int().nonnegative().default(0),
   limit: z.coerce.number().int().positive().max(300).min(25).default(25),
+  geo_type: z.enum(['boundary', 'proximity']).optional(),
 });
 
 export type SearchQueryDto = z.infer<typeof searchQuerySchema>;

--- a/src/search/dto/search-response.dto.ts
+++ b/src/search/dto/search-response.dto.ts
@@ -1,13 +1,198 @@
-// Top-level facets mapping (facet key -> human-readable name)
-export type SearchFacets = Record<string, string>;
+import { ApiProperty } from '@nestjs/swagger';
+
+// Top-level facets mapping (facet key -> human-readable name object)
+export type SearchFacets = Record<string, Record<string, string>>;
 
 // Per-document facet values: language -> array of values
 // Example: { area_served_by_county: { en: ['Dakota County'], es: ['Condado de Dakota'] } }
 export type DocumentFacets = Record<string, Record<string, string[]>>;
 
-// Search response shape returned by SearchController
-export type SearchResponse = {
-  search: any; // raw Elasticsearch response
+export class ServiceDto {
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ nullable: true })
+  alternate_name?: string | null;
+
+  @ApiProperty({ nullable: true })
+  description?: string | null;
+
+  @ApiProperty({ nullable: true })
+  summary?: string | null;
+}
+
+export class PhysicalAddressDto {
+  @ApiProperty({ nullable: true })
+  address_1?: string | null;
+
+  @ApiProperty({ nullable: true })
+  address_2?: string | null;
+
+  @ApiProperty({ nullable: true })
+  city?: string | null;
+
+  @ApiProperty({ nullable: true })
+  state?: string | null;
+
+  @ApiProperty({ nullable: true })
+  country?: string | null;
+
+  @ApiProperty({ nullable: true })
+  postal_code?: string | null;
+}
+
+export class LocationDto {
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ nullable: true })
+  alternate_name?: string | null;
+
+  @ApiProperty({ nullable: true })
+  description?: string | null;
+
+  @ApiProperty({ nullable: true })
+  summary?: string | null;
+
+  @ApiProperty({ nullable: true })
+  point?: { lat: number; lon: number } | [number, number] | string | null;
+
+  @ApiProperty({ type: PhysicalAddressDto, nullable: true })
+  physical_address?: PhysicalAddressDto | null;
+}
+
+export class OrganizationDto {
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ nullable: true })
+  alternate_name?: string | null;
+
+  @ApiProperty({ nullable: true })
+  description?: string | null;
+
+  @ApiProperty({ nullable: true })
+  summary?: string | null;
+}
+
+export class TaxonomyDto {
+  @ApiProperty()
+  code: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ nullable: true })
+  description?: string | null;
+}
+
+export class SearchSource {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  service_at_location_id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ nullable: true })
+  description?: string | null;
+
+  @ApiProperty({ nullable: true })
+  summary?: string | null;
+
+  @ApiProperty({ nullable: true })
+  phone?: string | null;
+
+  @ApiProperty({ nullable: true })
+  url?: string | null;
+
+  @ApiProperty({ nullable: true })
+  email?: string | null;
+
+  @ApiProperty({ nullable: true })
+  schedule?: string | null;
+
+  // Using simple object for geo_shape as it can be complex
+  @ApiProperty({ nullable: true })
+  service_area?: any | null;
+
+  @ApiProperty({ type: ServiceDto })
+  service: ServiceDto;
+
+  @ApiProperty({ type: LocationDto })
+  location: LocationDto;
+
+  @ApiProperty({ type: OrganizationDto })
+  organization: OrganizationDto;
+
+  @ApiProperty({ type: [TaxonomyDto] })
+  taxonomies: TaxonomyDto[];
+
+  @ApiProperty()
+  facets: DocumentFacets;
+
+  @ApiProperty()
+  tenant_id: string;
+
+  @ApiProperty()
+  priority: number;
+
+  @ApiProperty()
+  pinned: boolean;
+}
+
+export class SearchHit {
+  @ApiProperty()
+  _index: string;
+
+  @ApiProperty()
+  _id: string;
+
+  @ApiProperty({ nullable: true })
+  _score: number | null;
+
+  @ApiProperty({ nullable: true })
+  _routing?: string | null;
+
+  @ApiProperty({ type: SearchSource })
+  _source: SearchSource;
+
+  @ApiProperty({ type: [Number], nullable: true })
+  sort?: number[] | null;
+}
+
+export class SearchHitsContainer {
+  @ApiProperty({ example: { value: 100, relation: 'eq' } })
+  total: { value: number; relation: string };
+
+  @ApiProperty({ nullable: true })
+  max_score: number | null;
+
+  @ApiProperty({ type: [SearchHit] })
+  hits: SearchHit[];
+}
+
+export class SearchResponseDto {
+  @ApiProperty({ type: SearchHitsContainer })
+  search: {
+    took: number;
+    timed_out: boolean;
+    _shards: {
+      total: number;
+      successful: number;
+      skipped: number;
+      failed: number;
+    };
+    hits: SearchHitsContainer;
+  };
+
+  @ApiProperty()
   facets: SearchFacets;
-  facets_values?: Record<string, Record<string, string[]>>;
-};
+
+  @ApiProperty({ required: false })
+  facets_values?: DocumentFacets;
+}
+
+export type SearchResponse = SearchResponseDto;

--- a/src/search/dto/search-response.dto.ts
+++ b/src/search/dto/search-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Geometry } from 'geojson';
 
 // Top-level facets mapping (facet key -> human-readable name object)
 export type SearchFacets = Record<string, Record<string, string>>;
@@ -114,9 +115,8 @@ export class SearchSource {
   @ApiProperty({ nullable: true })
   schedule?: string | null;
 
-  // Using simple object for geo_shape as it can be complex
   @ApiProperty({ nullable: true })
-  service_area?: any | null;
+  service_area?: Geometry | null;
 
   @ApiProperty({ type: ServiceDto })
   service: ServiceDto;

--- a/src/search/dto/search-response.dto.ts
+++ b/src/search/dto/search-response.dto.ts
@@ -148,16 +148,18 @@ export class SearchHit {
   _index: string;
 
   @ApiProperty()
-  _id: string;
+  @ApiProperty({ required: false })
+  _id?: string;
 
   @ApiProperty({ nullable: true })
-  _score: number | null;
+  @ApiProperty({ nullable: true, required: false })
+  _score?: number | null;
 
   @ApiProperty({ nullable: true })
   _routing?: string | null;
 
-  @ApiProperty({ type: SearchSource })
-  _source: SearchSource;
+  @ApiProperty({ type: SearchSource, required: false })
+  _source?: SearchSource;
 
   @ApiProperty({ type: [Number], nullable: true })
   sort?: number[] | null;
@@ -165,10 +167,10 @@ export class SearchHit {
 
 export class SearchHitsContainer {
   @ApiProperty({ example: { value: 100, relation: 'eq' } })
-  total: { value: number; relation: string };
+  total?: { value: number; relation: string } | number;
 
   @ApiProperty({ nullable: true })
-  max_score: number | null;
+  max_score?: number | null;
 
   @ApiProperty({ type: [SearchHit] })
   hits: SearchHit[];
@@ -182,7 +184,7 @@ export class SearchResponseDto {
     _shards: {
       total: number;
       successful: number;
-      skipped: number;
+      skipped?: number;
       failed: number;
     };
     hits: SearchHitsContainer;

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -18,6 +18,7 @@ import {
 } from '@nestjs/swagger';
 import { ZodValidationPipe } from '../common/pipes/zod-validation-pipe';
 import { SearchQueryDto, searchQuerySchema } from './dto/search-query.dto';
+import { SearchResponseDto } from './dto/search-response.dto';
 import { SearchBodyDto, searchBodySchema } from './dto/search-body.dto';
 import { HeadersDto, headersSchema } from '../common/dto/headers.dto';
 import { CustomHeaders } from '../common/decorators/CustomHeaders';
@@ -41,112 +42,7 @@ export class SearchController {
   @Version('1')
   @ApiResponse({
     status: 200,
-    example: {
-      search: {
-        took: 5,
-        timed_out: false,
-        _shards: {
-          total: 1,
-          successful: 1,
-          skipped: 0,
-          failed: 0,
-        },
-        hits: {
-          total: {
-            value: 227,
-            relation: 'eq',
-          },
-          max_score: null,
-          hits: [
-            {
-              _index: 'results_v2_en',
-              _id: '00000000-0000-0000-0000-000000000000',
-              _score: null,
-              _routing: '00000000-0000-0000-0000-000000000000',
-              _source: {
-                id: '00000000-0000-0000-0000-000000000000',
-                service_at_location_id: '00000000-0000-0000-0000-000000000000',
-                service_id: '00000000-0000-0000-0000-000000000000',
-                location_id: '00000000-0000-0000-0000-000000000000',
-                organization_id: '00000000-0000-0000-0000-000000000000',
-                primary_email: 'info@example.com',
-                primary_phone: '(555) 555-555',
-                primary_website: 'https://www.example.com',
-                email: 'info@example.org',
-                phone: '(555) 555-5555',
-                website: 'https://www.example.com',
-                display_email: 'info@example.com',
-                display_phone_number: '(555) 555-5555',
-                display_website: 'https://www.example.com',
-                organization_name: 'EXAMPLE ORGANIZATION',
-                organization_alternate_name: null,
-                organization_description:
-                  'The example organization can help families and victims of disaster with immediate disaster caused needs including food, shelter and other needs. The example organization helps facilitate emergency messages for the Armed Forces. The example organization also provides CPR/AED and First Aid training to the community.',
-                organization_short_description: null,
-                location_latitude: null,
-                location_longitude: null,
-                service_name: 'MILITARY AND VETERAN CAREGIVER NETWORK',
-                service_alternate_name: null,
-                location_name: 'EXAMPLE LOCATION',
-                location_alternate_name: null,
-                location_description: null,
-                location_short_description: null,
-                display_name:
-                  'MILITARY AND VETERAN CAREGIVER NETWORK | EXAMPLE ORGANIZATION',
-                display_alternate_name: null,
-                display_description:
-                  'The Military and Veteran Caregiver Network (MVCN) offers peer-based support and services to connect those providing care to service members and veterans living with wounds, illnesses, injuries and/or aging.',
-                display_short_description: null,
-                service_description:
-                  'The Military and Veteran Caregiver Network (MVCN) offers peer-based support and services to connect those providing care to service members and veterans living with wounds, illnesses, injuries and/or aging.',
-                service_short_description: null,
-                address_1: 'Multiple Locations',
-                city: null,
-                state: null,
-                postal_code: null,
-                physical_address: 'Multiple Locations',
-                physical_address_1: 'Multiple Locations',
-                physical_address_2: null,
-                physical_address_city: null,
-                physical_address_state: null,
-                physical_address_postal_code: null,
-                physical_address_country: 'United States',
-                taxonomy_terms: ['Caregiver Consultation and Support'],
-                taxonomy_descriptions: [],
-                taxonomy_codes: ['NW-0000'],
-                location: {
-                  type: 'Point',
-                  coordinates: [0, 0],
-                },
-                location_coordinates: {
-                  type: 'Point',
-                  coordinates: [0, 0],
-                },
-                source_service_area: null,
-                tenant_id: '00000000-0000-0000-0000-000000000000',
-                days_open: null,
-                service_provided: null,
-                need_within: null,
-                facets: {
-                  area_served_by_county: {
-                    en: ['Dakota County', 'Hennepin County'],
-                  },
-                },
-                created_at: null,
-                updated_at: null,
-                priority: 0,
-              },
-              sort: [0],
-            },
-          ],
-        },
-      },
-      facets: {
-        area_served_by_county: {
-          en: ['Dakota County', 'Hennepin County'],
-        },
-      },
-    },
+    type: SearchResponseDto,
   })
   @ApiHeader({
     name: 'accept-language',
@@ -208,104 +104,8 @@ export class SearchController {
   @Version('1')
   @ApiResponse({
     status: 200,
-    example: {
-      search: {
-        took: 5,
-        timed_out: false,
-        _shards: {
-          total: 1,
-          successful: 1,
-          skipped: 0,
-          failed: 0,
-        },
-        hits: {
-          total: {
-            value: 227,
-            relation: 'eq',
-          },
-          max_score: null,
-          hits: [
-            {
-              _index: 'results_v2_en',
-              _id: '00000000-0000-0000-0000-000000000000',
-              _score: null,
-              _routing: '00000000-0000-0000-0000-000000000000',
-              _source: {
-                id: '00000000-0000-0000-0000-000000000000',
-                service_at_location_id: '00000000-0000-0000-0000-000000000000',
-                service_id: '00000000-0000-0000-0000-000000000000',
-                location_id: '00000000-0000-0000-0000-000000000000',
-                organization_id: '00000000-0000-0000-0000-000000000000',
-                primary_email: 'info@example.com',
-                primary_phone: '(555) 555-555',
-                primary_website: 'https://www.example.com',
-                email: 'info@example.org',
-                phone: '(555) 555-5555',
-                website: 'https://www.example.com',
-                display_email: 'info@example.com',
-                display_phone_number: '(555) 555-5555',
-                display_website: 'https://www.example.com',
-                organization_name: 'EXAMPLE ORGANIZATION',
-                organization_alternate_name: null,
-                organization_description:
-                  'The example organization can help families and victims of disaster with immediate disaster caused needs including food, shelter and other needs. The example organization helps facilitate emergency messages for the Armed Forces. The example organization also provides CPR/AED and First Aid training to the community.',
-                organization_short_description: null,
-                location_latitude: null,
-                location_longitude: null,
-                service_name: 'MILITARY AND VETERAN CAREGIVER NETWORK',
-                service_alternate_name: null,
-                location_name: 'EXAMPLE LOCATION',
-                location_alternate_name: null,
-                location_description: null,
-                location_short_description: null,
-                display_name:
-                  'MILITARY AND VETERAN CAREGIVER NETWORK | EXAMPLE ORGANIZATION',
-                display_alternate_name: null,
-                display_description:
-                  'The Military and Veteran Caregiver Network (MVCN) offers peer-based support and services to connect those providing care to service members and veterans living with wounds, illnesses, injuries and/or aging.',
-                display_short_description: null,
-                service_description:
-                  'The Military and Veteran Caregiver Network (MVCN) offers peer-based support and services to connect those providing care to service members and veterans living with wounds, illnesses, injuries and/or aging.',
-                service_short_description: null,
-                address_1: 'Multiple Locations',
-                city: null,
-                state: null,
-                postal_code: null,
-                physical_address: 'Multiple Locations',
-                physical_address_1: 'Multiple Locations',
-                physical_address_2: null,
-                physical_address_city: null,
-                physical_address_state: null,
-                physical_address_postal_code: null,
-                physical_address_country: 'United States',
-                taxonomy_terms: ['Caregiver Consultation and Support'],
-                taxonomy_descriptions: [],
-                taxonomy_codes: ['NW-0000'],
-                location: {
-                  type: 'Point',
-                  coordinates: [0, 0],
-                },
-                location_coordinates: {
-                  type: 'Point',
-                  coordinates: [0, 0],
-                },
-                source_service_area: null,
-                tenant_id: '00000000-0000-0000-0000-000000000000',
-                days_open: null,
-                service_provided: null,
-                need_within: null,
-                facets: {},
-                created_at: null,
-                updated_at: null,
-                priority: 0,
-              },
-              sort: [0],
-            },
-          ],
-        },
-      },
-      facets: {},
-    },
+    description: 'Search resources (POST)',
+    type: SearchResponseDto,
   })
   @ApiHeader({
     name: 'accept-language',

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -1,6 +1,21 @@
-import { Controller, Get, Post, Query, Body, Req, Version, BadRequestException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Query,
+  Body,
+  Req,
+  Version,
+  BadRequestException,
+} from '@nestjs/common';
 import { SearchService } from './search.service';
-import { ApiHeader, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiHeader,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { ZodValidationPipe } from '../common/pipes/zod-validation-pipe';
 import { SearchQueryDto, searchQuerySchema } from './dto/search-query.dto';
 import { SearchBodyDto, searchBodySchema } from './dto/search-body.dto';
@@ -193,8 +208,104 @@ export class SearchController {
   @Version('1')
   @ApiResponse({
     status: 200,
-    description: 'Search resources (POST)',
-    // Reuse the same example/schema as GET if possible, or duplicate the ApiResponse from GET
+    example: {
+      search: {
+        took: 5,
+        timed_out: false,
+        _shards: {
+          total: 1,
+          successful: 1,
+          skipped: 0,
+          failed: 0,
+        },
+        hits: {
+          total: {
+            value: 227,
+            relation: 'eq',
+          },
+          max_score: null,
+          hits: [
+            {
+              _index: 'results_v2_en',
+              _id: '00000000-0000-0000-0000-000000000000',
+              _score: null,
+              _routing: '00000000-0000-0000-0000-000000000000',
+              _source: {
+                id: '00000000-0000-0000-0000-000000000000',
+                service_at_location_id: '00000000-0000-0000-0000-000000000000',
+                service_id: '00000000-0000-0000-0000-000000000000',
+                location_id: '00000000-0000-0000-0000-000000000000',
+                organization_id: '00000000-0000-0000-0000-000000000000',
+                primary_email: 'info@example.com',
+                primary_phone: '(555) 555-555',
+                primary_website: 'https://www.example.com',
+                email: 'info@example.org',
+                phone: '(555) 555-5555',
+                website: 'https://www.example.com',
+                display_email: 'info@example.com',
+                display_phone_number: '(555) 555-5555',
+                display_website: 'https://www.example.com',
+                organization_name: 'EXAMPLE ORGANIZATION',
+                organization_alternate_name: null,
+                organization_description:
+                  'The example organization can help families and victims of disaster with immediate disaster caused needs including food, shelter and other needs. The example organization helps facilitate emergency messages for the Armed Forces. The example organization also provides CPR/AED and First Aid training to the community.',
+                organization_short_description: null,
+                location_latitude: null,
+                location_longitude: null,
+                service_name: 'MILITARY AND VETERAN CAREGIVER NETWORK',
+                service_alternate_name: null,
+                location_name: 'EXAMPLE LOCATION',
+                location_alternate_name: null,
+                location_description: null,
+                location_short_description: null,
+                display_name:
+                  'MILITARY AND VETERAN CAREGIVER NETWORK | EXAMPLE ORGANIZATION',
+                display_alternate_name: null,
+                display_description:
+                  'The Military and Veteran Caregiver Network (MVCN) offers peer-based support and services to connect those providing care to service members and veterans living with wounds, illnesses, injuries and/or aging.',
+                display_short_description: null,
+                service_description:
+                  'The Military and Veteran Caregiver Network (MVCN) offers peer-based support and services to connect those providing care to service members and veterans living with wounds, illnesses, injuries and/or aging.',
+                service_short_description: null,
+                address_1: 'Multiple Locations',
+                city: null,
+                state: null,
+                postal_code: null,
+                physical_address: 'Multiple Locations',
+                physical_address_1: 'Multiple Locations',
+                physical_address_2: null,
+                physical_address_city: null,
+                physical_address_state: null,
+                physical_address_postal_code: null,
+                physical_address_country: 'United States',
+                taxonomy_terms: ['Caregiver Consultation and Support'],
+                taxonomy_descriptions: [],
+                taxonomy_codes: ['NW-0000'],
+                location: {
+                  type: 'Point',
+                  coordinates: [0, 0],
+                },
+                location_coordinates: {
+                  type: 'Point',
+                  coordinates: [0, 0],
+                },
+                source_service_area: null,
+                tenant_id: '00000000-0000-0000-0000-000000000000',
+                days_open: null,
+                service_provided: null,
+                need_within: null,
+                facets: {},
+                created_at: null,
+                updated_at: null,
+                priority: 0,
+              },
+              sort: [0],
+            },
+          ],
+        },
+      },
+      facets: {},
+    },
   })
   @ApiHeader({
     name: 'accept-language',
@@ -203,8 +314,49 @@ export class SearchController {
     },
   })
   @ApiHeader({ name: 'x-tenant-id', required: true })
-  @ApiHeader({ name: 'Content-Type', required: true, description: 'application/json' })
+  @ApiHeader({
+    name: 'Content-Type',
+    required: true,
+    description: 'application/json',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    schema: { minimum: 25, maximum: 300, default: 25, type: 'integer' },
+  })
+  @ApiQuery({
+    name: 'distance',
+    required: false,
+    schema: { default: 0, type: 'integer', minimum: 0 },
+  })
+  @ApiQuery({ name: 'filters', required: false, schema: { type: 'object' } })
+  @ApiQuery({
+    name: 'coords',
+    required: false,
+    description: 'Comma delimited list of longitude,latitude',
+    schema: {
+      example: '-120.740135,47.751076',
+    },
+  })
+  @ApiQuery({ name: 'page', required: false, schema: { default: 1 } })
+  @ApiQuery({
+    name: 'query_type',
+    required: false,
+    enum: ['text', 'taxonomy', 'more_like_this'],
+    schema: { default: 'text' },
+  })
   @ApiQueryForComplexSearch()
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        geometry: {
+          type: 'object',
+          description: 'GeoJSON geometry',
+        },
+      },
+    },
+  })
   getResourcesPost(
     @CustomHeaders(new ZodValidationPipe(headersSchema)) headers: HeadersDto,
     @Query(new ZodValidationPipe(searchQuerySchema)) query: SearchQueryDto,
@@ -214,9 +366,7 @@ export class SearchController {
     // Validate Content-Type
     const contentType = req.headers['content-type'];
     if (!contentType || !contentType.includes('application/json')) {
-      throw new BadRequestException(
-        'Content-Type must be application/json',
-      );
+      throw new BadRequestException('Content-Type must be application/json');
     }
 
     return this.searchService.searchResources({

--- a/src/search/search.service.filter.spec.ts
+++ b/src/search/search.service.filter.spec.ts
@@ -7,12 +7,11 @@ import { SearchBodyDto } from './dto/search-body.dto';
 
 describe('SearchService Logic', () => {
   let service: SearchService;
-  let esService: ElasticsearchService;
 
   const mockEsService = {
     search: jest.fn().mockResolvedValue({
-        aggregations: {}, 
-        hits: { hits: [], total: { value: 0 } }
+      aggregations: {},
+      hits: { hits: [], total: { value: 0 } },
     }),
   };
 
@@ -28,115 +27,169 @@ describe('SearchService Logic', () => {
     }).compile();
 
     service = module.get<SearchService>(SearchService);
-    esService = module.get<ElasticsearchService>(ElasticsearchService);
+
     jest.clearAllMocks();
   });
 
   const getFiltersFromLastCall = () => {
-      const callArgs = mockEsService.search.mock.calls[0][0]; 
-      return callArgs.query.bool.filter;
+    const callArgs = mockEsService.search.mock.calls[0][0];
+    return callArgs.query.bool.filter;
   };
 
-  const baseQuery: SearchQueryDto = { 
-      query: '', 
-      page: 1, 
-      limit: 25, 
-      filters: {},
-      distance: 0,
-      query_type: 'text'
+  const baseQuery: SearchQueryDto = {
+    query: '',
+    page: 1,
+    limit: 25,
+    filters: {},
+    distance: 0,
+    query_type: 'text',
   };
 
   it('should apply boundary search filter', async () => {
-      const query: SearchQueryDto = { ...baseQuery, geo_type: 'boundary' };
-      const geometry: any = { type: 'Polygon', coordinates: [[[0,0], [1,0], [1,1], [0,1], [0,0]]] };
-      const body: SearchBodyDto = { geometry };
-      
-      await service.searchResources({ headers: {} as any, query, body, tenant: {} as any });
-      
-      const filters = getFiltersFromLastCall();
-      const geoShapeFilter = filters.find(f => f.geo_shape && f.geo_shape.service_area);
-      expect(geoShapeFilter).toBeDefined();
-      expect(geoShapeFilter.geo_shape.service_area.relation).toBe('intersects');
-      expect(geoShapeFilter.geo_shape.service_area.shape).toEqual(geometry);
+    const query: SearchQueryDto = { ...baseQuery, geo_type: 'boundary' };
+    const geometry: any = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 1],
+          [0, 0],
+        ],
+      ],
+    };
+    const body: SearchBodyDto = { geometry };
+
+    await service.searchResources({
+      headers: {} as any,
+      query,
+      body,
+      tenant: {} as any,
+    });
+
+    const filters = getFiltersFromLastCall();
+    const geoShapeFilter = filters.find(
+      (f) => f.geo_shape && f.geo_shape.service_area,
+    );
+    expect(geoShapeFilter).toBeDefined();
+    expect(geoShapeFilter.geo_shape.service_area.relation).toBe('intersects');
+    expect(geoShapeFilter.geo_shape.service_area.shape).toEqual(geometry);
   });
 
   it('should throw BadRequestException if boundary search missing geometry', async () => {
-      const query: SearchQueryDto = { ...baseQuery, geo_type: 'boundary' };
-      
-      await expect(service.searchResources({ headers: {} as any, query, tenant: {} as any }))
-        .rejects.toThrow(BadRequestException);
+    const query: SearchQueryDto = { ...baseQuery, geo_type: 'boundary' };
+
+    await expect(
+      service.searchResources({ headers: {} as any, query, tenant: {} as any }),
+    ).rejects.toThrow(BadRequestException);
   });
 
   it('should apply double filtering for proximity search (coords + distance > 0)', async () => {
-      const query: SearchQueryDto = { ...baseQuery, coords: [-93.2, 44.9], distance: 10 };
-      
-      await service.searchResources({ headers: {} as any, query, tenant: {} as any });
-      
-      const filters = getFiltersFromLastCall();
-      
-      // Filter 1: Service Area Contains
-      const svcAreaFilter = filters.find(f => f.geo_shape && f.geo_shape.service_area);
-      expect(svcAreaFilter).toBeDefined();
-      expect(svcAreaFilter.geo_shape.service_area.relation).toBe('contains');
-      expect(svcAreaFilter.geo_shape.service_area.shape.coordinates).toEqual([-93.2, 44.9]);
+    const query: SearchQueryDto = {
+      ...baseQuery,
+      coords: [-93.2, 44.9],
+      distance: 10,
+    };
 
-      // Filter 2: Geo Distance
-      // Implementation wraps it in bool -> should -> bool -> must -> geo_distance
-      // Or just look for any filter that has bool logic
-      // In code: filters.push({ bool: { should: [ ... ] } })
-      const boolFilter = filters.find(f => f.bool && f.bool.should);
-      expect(boolFilter).toBeDefined();
-      
-      // Dig deeper to find geo_distance
-      const shouldClauses = boolFilter.bool.should;
-      const mustDate = shouldClauses.find(c => c.bool && c.bool.must);
-      const geoDist = mustDate.bool.must.find(m => m.geo_distance);
-      
-      expect(geoDist).toBeDefined();
-      expect(geoDist.geo_distance.distance).toBe('10miles');
-      expect(geoDist.geo_distance['location.point']).toEqual({ lon: -93.2, lat: 44.9 });
+    await service.searchResources({
+      headers: {} as any,
+      query,
+      tenant: {} as any,
+    });
+
+    const filters = getFiltersFromLastCall();
+
+    // Filter 1: Service Area Contains
+    const svcAreaFilter = filters.find(
+      (f) => f.geo_shape && f.geo_shape.service_area,
+    );
+    expect(svcAreaFilter).toBeDefined();
+    expect(svcAreaFilter.geo_shape.service_area.relation).toBe('contains');
+    expect(svcAreaFilter.geo_shape.service_area.shape.coordinates).toEqual([
+      -93.2, 44.9,
+    ]);
+
+    // Filter 2: Geo Distance
+    // Implementation wraps it in bool -> should -> bool -> must -> geo_distance
+    // Or just look for any filter that has bool logic
+    // In code: filters.push({ bool: { should: [ ... ] } })
+    const boolFilter = filters.find((f) => f.bool && f.bool.should);
+    expect(boolFilter).toBeDefined();
+
+    // Dig deeper to find geo_distance
+    const shouldClauses = boolFilter.bool.should;
+    const mustDate = shouldClauses.find((c) => c.bool && c.bool.must);
+    const geoDist = mustDate.bool.must.find((m) => m.geo_distance);
+
+    expect(geoDist).toBeDefined();
+    expect(geoDist.geo_distance.distance).toBe('10miles');
+    expect(geoDist.geo_distance['location.point']).toEqual({
+      lon: -93.2,
+      lat: 44.9,
+    });
   });
 
   it('should apply ONLY service area filter for proximity search (distance = 0)', async () => {
-      const query: SearchQueryDto = { ...baseQuery, coords: [-93.2, 44.9], distance: 0 };
-      
-      await service.searchResources({ headers: {} as any, query, tenant: {} as any });
-      
-      const filters = getFiltersFromLastCall();
-      
-      const svcAreaFilter = filters.find(f => f.geo_shape && f.geo_shape.service_area);
-      expect(svcAreaFilter).toBeDefined();
-      
-      // Should NOT have geo_distance filter
-      const boolFilter = filters.find(f => f.bool && f.bool.should); // This was the complex double filter structure
-      expect(boolFilter).toBeUndefined();
+    const query: SearchQueryDto = {
+      ...baseQuery,
+      coords: [-93.2, 44.9],
+      distance: 0,
+    };
+
+    await service.searchResources({
+      headers: {} as any,
+      query,
+      tenant: {} as any,
+    });
+
+    const filters = getFiltersFromLastCall();
+
+    const svcAreaFilter = filters.find(
+      (f) => f.geo_shape && f.geo_shape.service_area,
+    );
+    expect(svcAreaFilter).toBeDefined();
+
+    // Should NOT have geo_distance filter
+    const boolFilter = filters.find((f) => f.bool && f.bool.should); // This was the complex double filter structure
+    expect(boolFilter).toBeUndefined();
   });
 
   it('should apply ONLY service area filter for proximity search (no distance provided)', async () => {
-     // DTO default is 0, so strict check if undefined behaves like 0 is covered by DTO logic.
-     // But let's testing passing explicitly undefined distance if possible, or just rely on default.
-     // The DTO ensures distance is 0 if missing.
-     const query: SearchQueryDto = { ...baseQuery, coords: [-93.2, 44.9] };
-      
-      await service.searchResources({ headers: {} as any, query, tenant: {} as any });
-      
-      const filters = getFiltersFromLastCall();
-      const svcAreaFilter = filters.find(f => f.geo_shape && f.geo_shape.service_area);
-      expect(svcAreaFilter).toBeDefined();
-      const boolFilter = filters.find(f => f.bool && f.bool.should);
-      expect(boolFilter).toBeUndefined();
+    // DTO default is 0, so strict check if undefined behaves like 0 is covered by DTO logic.
+    // But let's testing passing explicitly undefined distance if possible, or just rely on default.
+    // The DTO ensures distance is 0 if missing.
+    const query: SearchQueryDto = { ...baseQuery, coords: [-93.2, 44.9] };
+
+    await service.searchResources({
+      headers: {} as any,
+      query,
+      tenant: {} as any,
+    });
+
+    const filters = getFiltersFromLastCall();
+    const svcAreaFilter = filters.find(
+      (f) => f.geo_shape && f.geo_shape.service_area,
+    );
+    expect(svcAreaFilter).toBeDefined();
+    const boolFilter = filters.find((f) => f.bool && f.bool.should);
+    expect(boolFilter).toBeUndefined();
   });
 
   it('should apply NO geo filters if no coords provided', async () => {
-      const query: SearchQueryDto = { ...baseQuery, distance: 10 }; // Distance ignored without coords
-      
-      await service.searchResources({ headers: {} as any, query, tenant: {} as any });
-      
-      const filters = getFiltersFromLastCall();
-      const svcAreaFilter = filters.find(f => f.geo_shape);
-      const boolFilter = filters.find(f => f.bool && f.bool.should);
-      
-      expect(svcAreaFilter).toBeUndefined();
-      expect(boolFilter).toBeUndefined();
+    const query: SearchQueryDto = { ...baseQuery, distance: 10 }; // Distance ignored without coords
+
+    await service.searchResources({
+      headers: {} as any,
+      query,
+      tenant: {} as any,
+    });
+
+    const filters = getFiltersFromLastCall();
+    const svcAreaFilter = filters.find((f) => f.geo_shape);
+    const boolFilter = filters.find((f) => f.bool && f.bool.should);
+
+    expect(svcAreaFilter).toBeUndefined();
+    expect(boolFilter).toBeUndefined();
   });
 });

--- a/src/search/search.service.filter.spec.ts
+++ b/src/search/search.service.filter.spec.ts
@@ -1,0 +1,142 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SearchService } from './search.service';
+import { ElasticsearchService } from '@nestjs/elasticsearch';
+import { SearchQueryDto } from './dto/search-query.dto';
+import { BadRequestException } from '@nestjs/common';
+import { SearchBodyDto } from './dto/search-body.dto';
+
+describe('SearchService Logic', () => {
+  let service: SearchService;
+  let esService: ElasticsearchService;
+
+  const mockEsService = {
+    search: jest.fn().mockResolvedValue({
+        aggregations: {}, 
+        hits: { hits: [], total: { value: 0 } }
+    }),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SearchService,
+        {
+          provide: ElasticsearchService,
+          useValue: mockEsService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SearchService>(SearchService);
+    esService = module.get<ElasticsearchService>(ElasticsearchService);
+    jest.clearAllMocks();
+  });
+
+  const getFiltersFromLastCall = () => {
+      const callArgs = mockEsService.search.mock.calls[0][0]; 
+      return callArgs.query.bool.filter;
+  };
+
+  const baseQuery: SearchQueryDto = { 
+      query: '', 
+      page: 1, 
+      limit: 25, 
+      filters: {},
+      distance: 0,
+      query_type: 'text'
+  };
+
+  it('should apply boundary search filter', async () => {
+      const query: SearchQueryDto = { ...baseQuery, geo_type: 'boundary' };
+      const geometry: any = { type: 'Polygon', coordinates: [[[0,0], [1,0], [1,1], [0,1], [0,0]]] };
+      const body: SearchBodyDto = { geometry };
+      
+      await service.searchResources({ headers: {} as any, query, body, tenant: {} as any });
+      
+      const filters = getFiltersFromLastCall();
+      const geoShapeFilter = filters.find(f => f.geo_shape && f.geo_shape.service_area);
+      expect(geoShapeFilter).toBeDefined();
+      expect(geoShapeFilter.geo_shape.service_area.relation).toBe('intersects');
+      expect(geoShapeFilter.geo_shape.service_area.shape).toEqual(geometry);
+  });
+
+  it('should throw BadRequestException if boundary search missing geometry', async () => {
+      const query: SearchQueryDto = { ...baseQuery, geo_type: 'boundary' };
+      
+      await expect(service.searchResources({ headers: {} as any, query, tenant: {} as any }))
+        .rejects.toThrow(BadRequestException);
+  });
+
+  it('should apply double filtering for proximity search (coords + distance > 0)', async () => {
+      const query: SearchQueryDto = { ...baseQuery, coords: [-93.2, 44.9], distance: 10 };
+      
+      await service.searchResources({ headers: {} as any, query, tenant: {} as any });
+      
+      const filters = getFiltersFromLastCall();
+      
+      // Filter 1: Service Area Contains
+      const svcAreaFilter = filters.find(f => f.geo_shape && f.geo_shape.service_area);
+      expect(svcAreaFilter).toBeDefined();
+      expect(svcAreaFilter.geo_shape.service_area.relation).toBe('contains');
+      expect(svcAreaFilter.geo_shape.service_area.shape.coordinates).toEqual([-93.2, 44.9]);
+
+      // Filter 2: Geo Distance
+      // Implementation wraps it in bool -> should -> bool -> must -> geo_distance
+      // Or just look for any filter that has bool logic
+      // In code: filters.push({ bool: { should: [ ... ] } })
+      const boolFilter = filters.find(f => f.bool && f.bool.should);
+      expect(boolFilter).toBeDefined();
+      
+      // Dig deeper to find geo_distance
+      const shouldClauses = boolFilter.bool.should;
+      const mustDate = shouldClauses.find(c => c.bool && c.bool.must);
+      const geoDist = mustDate.bool.must.find(m => m.geo_distance);
+      
+      expect(geoDist).toBeDefined();
+      expect(geoDist.geo_distance.distance).toBe('10miles');
+      expect(geoDist.geo_distance['location.point']).toEqual({ lon: -93.2, lat: 44.9 });
+  });
+
+  it('should apply ONLY service area filter for proximity search (distance = 0)', async () => {
+      const query: SearchQueryDto = { ...baseQuery, coords: [-93.2, 44.9], distance: 0 };
+      
+      await service.searchResources({ headers: {} as any, query, tenant: {} as any });
+      
+      const filters = getFiltersFromLastCall();
+      
+      const svcAreaFilter = filters.find(f => f.geo_shape && f.geo_shape.service_area);
+      expect(svcAreaFilter).toBeDefined();
+      
+      // Should NOT have geo_distance filter
+      const boolFilter = filters.find(f => f.bool && f.bool.should); // This was the complex double filter structure
+      expect(boolFilter).toBeUndefined();
+  });
+
+  it('should apply ONLY service area filter for proximity search (no distance provided)', async () => {
+     // DTO default is 0, so strict check if undefined behaves like 0 is covered by DTO logic.
+     // But let's testing passing explicitly undefined distance if possible, or just rely on default.
+     // The DTO ensures distance is 0 if missing.
+     const query: SearchQueryDto = { ...baseQuery, coords: [-93.2, 44.9] };
+      
+      await service.searchResources({ headers: {} as any, query, tenant: {} as any });
+      
+      const filters = getFiltersFromLastCall();
+      const svcAreaFilter = filters.find(f => f.geo_shape && f.geo_shape.service_area);
+      expect(svcAreaFilter).toBeDefined();
+      const boolFilter = filters.find(f => f.bool && f.bool.should);
+      expect(boolFilter).toBeUndefined();
+  });
+
+  it('should apply NO geo filters if no coords provided', async () => {
+      const query: SearchQueryDto = { ...baseQuery, distance: 10 }; // Distance ignored without coords
+      
+      await service.searchResources({ headers: {} as any, query, tenant: {} as any });
+      
+      const filters = getFiltersFromLastCall();
+      const svcAreaFilter = filters.find(f => f.geo_shape);
+      const boolFilter = filters.find(f => f.bool && f.bool.should);
+      
+      expect(svcAreaFilter).toBeUndefined();
+      expect(boolFilter).toBeUndefined();
+  });
+});

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -15,7 +15,7 @@ import {
   Sort,
 } from '@elastic/elasticsearch/lib/api/types';
 import { getIndexName } from 'src/common/lib/utils';
-import { SearchResponse } from './dto/search-response.dto';
+import { SearchResponse, SearchSource } from './dto/search-response.dto';
 
 type QueryType =
   (typeof SearchService.QUERY_TYPE)[keyof typeof SearchService.QUERY_TYPE];
@@ -179,7 +179,8 @@ export class SearchService {
       ...specificQuery,
     };
 
-    const data = await this.elasticsearchService.search(finalQuery);
+    const data =
+      await this.elasticsearchService.search<SearchSource>(finalQuery);
 
     // Normalize document-level facets
     if (data.hits?.hits) {
@@ -187,7 +188,7 @@ export class SearchService {
         if (hit._source) {
           const src = hit._source as ResourceDocument;
           src.facets = this.normalizeDocFacets(src, locale);
-          hit._source = src;
+          hit._source = src as SearchSource;
         }
         return hit;
       });

--- a/src/taxonomy/dto/taxonomy-response.dto.ts
+++ b/src/taxonomy/dto/taxonomy-response.dto.ts
@@ -1,0 +1,67 @@
+/**
+ * Represents a taxonomy document from the taxonomies_v2 Elasticsearch index
+ */
+export interface TaxonomyDocument {
+  /** Taxonomy name (search_as_you_type field) */
+  name: string;
+
+  /** Taxonomy description */
+  description?: string;
+
+  /** Taxonomy ID (non-indexed text field) */
+  id: string;
+
+  /** Taxonomy classification/category */
+  taxonomy?: string;
+
+  /** Tenant identifier */
+  tenant_id: string;
+
+  /** Taxonomy code (search_as_you_type with raw keyword) */
+  code: string;
+
+  /** Type of taxonomy entry */
+  type?: string;
+
+  /** Creation timestamp */
+  created_at: string | Date;
+
+  /** Last update timestamp */
+  updated_at: string | Date;
+}
+
+/**
+ * Elasticsearch search hit for taxonomy documents
+ */
+export interface TaxonomyHit {
+  _index: string;
+  _id?: string;
+  _score?: number | null;
+  _source?: TaxonomyDocument;
+}
+
+/**
+ * Response from taxonomy search operations
+ * Aligned with Elasticsearch SearchResponse structure
+ */
+export interface TaxonomySearchResponse {
+  hits: {
+    total?:
+      | number
+      | {
+          value: number;
+          relation: string;
+        };
+    max_score?: number | null;
+    hits: TaxonomyHit[];
+  };
+  took?: number;
+  timed_out?: boolean;
+  _shards?: {
+    total: number;
+    successful: number;
+    skipped?: number;
+    failed: number;
+  };
+  aggregations?: Record<string, any>;
+}

--- a/src/taxonomy/taxonomy.controller.ts
+++ b/src/taxonomy/taxonomy.controller.ts
@@ -1,6 +1,12 @@
 import { Controller, Get, Query, Version } from '@nestjs/common';
 import { TaxonomyService } from './taxonomy.service';
-import { ApiHeader, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiHeader,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { CustomHeaders } from 'src/common/decorators/CustomHeaders';
 import { ZodValidationPipe } from 'src/common/pipes/zod-validation-pipe';
 import { HeadersDto, headersSchema } from 'src/common/dto/headers.dto';
@@ -9,6 +15,7 @@ import {
   TaxonomyTermsQueryDto,
   taxonomyTermsQuerySchema,
 } from './dto/taxonomy-terms-query.dto';
+import { TaxonomySearchResponse } from './dto/taxonomy-response.dto';
 
 @ApiTags('Taxonomy')
 @Controller('taxonomy')
@@ -17,23 +24,121 @@ export class TaxonomyController {
 
   @Get()
   @Version('1')
+  @ApiOperation({
+    summary: 'Search taxonomies',
+    description:
+      'Search for taxonomies by name or code using prefix matching. Supports pagination.',
+  })
   @ApiResponse({
     status: 200,
+    description: 'Successfully retrieved taxonomy search results',
+    schema: {
+      type: 'object',
+      properties: {
+        hits: {
+          type: 'object',
+          properties: {
+            total: {
+              oneOf: [
+                { type: 'number' },
+                {
+                  type: 'object',
+                  properties: {
+                    value: { type: 'number' },
+                    relation: { type: 'string', example: 'eq' },
+                  },
+                },
+              ],
+            },
+            max_score: { type: 'number', nullable: true },
+            hits: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  _index: { type: 'string' },
+                  _id: { type: 'string' },
+                  _score: { type: 'number' },
+                  _source: {
+                    type: 'object',
+                    properties: {
+                      name: { type: 'string', description: 'Taxonomy name' },
+                      description: {
+                        type: 'string',
+                        description: 'Taxonomy description',
+                      },
+                      id: { type: 'string', description: 'Taxonomy ID' },
+                      taxonomy: {
+                        type: 'string',
+                        description: 'Taxonomy classification',
+                      },
+                      tenant_id: {
+                        type: 'string',
+                        description: 'Tenant identifier',
+                      },
+                      code: { type: 'string', description: 'Taxonomy code' },
+                      type: { type: 'string', description: 'Taxonomy type' },
+                      created_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Creation timestamp',
+                      },
+                      updated_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Last update timestamp',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        took: { type: 'number', description: 'Query execution time in ms' },
+        timed_out: { type: 'boolean', description: 'Whether query timed out' },
+      },
+    },
   })
-  @ApiQuery({ name: 'query', required: false })
-  @ApiQuery({ name: 'code', required: false, deprecated: true })
-  @ApiQuery({ name: 'page', required: false, schema: { default: 1 } })
-  @ApiHeader({ name: 'x-tenant-id', required: true })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - query or code parameter is required',
+  })
+  @ApiQuery({
+    name: 'query',
+    required: false,
+    description:
+      'Search query for taxonomy name or code. Uses prefix matching.',
+    example: 'NAICS',
+  })
+  @ApiQuery({
+    name: 'code',
+    required: false,
+    deprecated: true,
+    description: 'Deprecated: Use query parameter instead',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    schema: { default: 1 },
+    description: 'Page number for pagination (10 results per page)',
+    example: 1,
+  })
+  @ApiHeader({
+    name: 'x-tenant-id',
+    required: true,
+    description: 'Tenant identifier',
+  })
   @ApiHeader({
     name: 'accept-language',
-    schema: {
-      default: 'en',
-    },
+    required: false,
+    schema: { default: 'en' },
+    description: 'Language preference for results',
   })
   getTaxonomies(
     @CustomHeaders(new ZodValidationPipe(headersSchema)) headers: HeadersDto,
     @Query(new ZodValidationPipe(searchQuerySchema)) query: SearchQueryDto,
-  ) {
+  ): Promise<TaxonomySearchResponse> {
     return this.taxonomyService.searchTaxonomies({
       headers,
       query,
@@ -42,11 +147,38 @@ export class TaxonomyController {
 
   @Get('term')
   @Version('1')
+  @ApiOperation({
+    summary: 'Get taxonomy terms by codes',
+    description:
+      'Retrieve specific taxonomy terms by their exact codes. Accepts single code or array of codes.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Successfully retrieved taxonomy terms',
+  })
+  @ApiQuery({
+    name: 'terms',
+    required: false,
+    description:
+      'Taxonomy code(s) to look up. Can be a single code or comma-separated codes.',
+    example: 'NAICS-11',
+  })
+  @ApiHeader({
+    name: 'x-tenant-id',
+    required: true,
+    description: 'Tenant identifier',
+  })
+  @ApiHeader({
+    name: 'accept-language',
+    required: false,
+    schema: { default: 'en' },
+    description: 'Language preference for results',
+  })
   getTaxonomyTermsByCode(
     @CustomHeaders(new ZodValidationPipe(headersSchema)) headers: HeadersDto,
     @Query(new ZodValidationPipe(taxonomyTermsQuerySchema))
     query: TaxonomyTermsQueryDto,
-  ) {
+  ): Promise<TaxonomySearchResponse> {
     return this.taxonomyService.getTaxonomyTermsForCodes({
       headers,
       query,

--- a/src/taxonomy/taxonomy.service.ts
+++ b/src/taxonomy/taxonomy.service.ts
@@ -3,6 +3,10 @@ import { HeadersDto } from 'src/common/dto/headers.dto';
 import { SearchQueryDto } from './dto/search-query.dto';
 import { ElasticsearchService } from '@nestjs/elasticsearch';
 import { TaxonomyTermsQueryDto } from './dto/taxonomy-terms-query.dto';
+import {
+  TaxonomyDocument,
+  TaxonomySearchResponse,
+} from './dto/taxonomy-response.dto';
 import { getIndexName } from 'src/common/lib/utils';
 
 const isTaxonomyCode = new RegExp(
@@ -20,7 +24,7 @@ export class TaxonomyService {
   async searchTaxonomies(options: {
     headers: HeadersDto;
     query: SearchQueryDto;
-  }) {
+  }): Promise<TaxonomySearchResponse> {
     try {
       const q = options.query;
       const { headers } = options;
@@ -82,7 +86,8 @@ export class TaxonomyService {
         `queryBuilder = ${JSON.stringify(queryBuilder, null, 2)}`,
       );
 
-      const data = await this.elasticsearchService.search(queryBuilder);
+      const data =
+        await this.elasticsearchService.search<TaxonomyDocument>(queryBuilder);
 
       return data;
     } catch (err) {
@@ -93,7 +98,7 @@ export class TaxonomyService {
   async getTaxonomyTermsForCodes(options: {
     headers: HeadersDto;
     query: TaxonomyTermsQueryDto;
-  }) {
+  }): Promise<TaxonomySearchResponse> {
     const q = options.query;
     const { headers } = options;
 
@@ -112,7 +117,8 @@ export class TaxonomyService {
 
     let data;
     try {
-      data = await this.elasticsearchService.search(queryBuilder);
+      data =
+        await this.elasticsearchService.search<TaxonomyDocument>(queryBuilder);
       this.logger.debug(
         `Data for code=${q?.terms}, data=${JSON.stringify(data, null, 2)}`,
       );


### PR DESCRIPTION
### Description
This PR introduces a new POST /search endpoint to support complex geographic queries that cannot be easily handled via URL parameters. It implements "Conditional Filtering" logic to correctly distinguish between checking if a user is eligible for a service (Service Area) versus if a user is physically close to an office (Proximity).

### Key Changes
**New Endpoint (POST /search):**
Supports a hybrid parameter approach: standard filters (query, distance) remain in the query string, while complex geometry (GeoJSON) is passed in the request body.
Enforces Content-Type: application/json and X-API-Version: 1.

**Boundary Search Support:**
Added geo_type=boundary mode.
Filters services whose service_area intersects with the custom Polygon provided in the request body (e.g., a state or county bounding box or complex custom boundary).

**Refined Proximity Logic:**
Double Filtering (Distance > 0): Now applies two strict filters. The user must be inside the service area (eligibility) AND the office must be within the specified radius (accessibility).
Service Area Only (Distance = 0 implied): If distance is 0 or not provided, it filters ONLY on service area (eligibility) same as before. This correctly handles virtual services or "service available anywhere in this area" scenarios.
Text Only: if no coordinates are provided + not a boundary type search or if the boundary type search is invalid, we permissively fall back to a search with no geographic filtering

This opens the possibility for more sophisticated geographic filtering functionality including bbox and complex geojson filtering parameters.  **NOTABLY will always use intersects for the boundary with the service_area currently! This is the expressly desired functionality for service_area even in shape to shape comparisons**