### PR TITLE
feat(CON-510): get taxonomies v2 endpoint

### DIFF
--- a/src/taxonomy/dto/taxonomy-response.dto.ts
+++ b/src/taxonomy/dto/taxonomy-response.dto.ts
@@ -1,3 +1,5 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 /**
  * Represents a taxonomy document from the taxonomies_v2 Elasticsearch index
  */
@@ -64,4 +66,44 @@ export interface TaxonomySearchResponse {
     failed: number;
   };
   aggregations?: Record<string, any>;
+}
+
+export class TaxonomyItemDto {
+  @ApiProperty({
+    description: 'Unique identifier of the taxonomy term',
+    example: 'ee9dd652-19d7-5226-bd7c-3c01f8144f2a',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Taxonomy code',
+    example: 'FT-2700.9500',
+  })
+  code: string;
+
+  @ApiProperty({
+    description: 'Taxonomy term name',
+    example: 'Will Preparation Assistance',
+  })
+  name: string;
+}
+
+export class TaxonomyResponseDto {
+  @ApiProperty({
+    description: 'Total number of matching results',
+    example: 69,
+  })
+  total: number;
+
+  @ApiProperty({
+    description: 'Array of taxonomy items',
+    type: [TaxonomyItemDto],
+  })
+  items: TaxonomyItemDto[];
+
+  @ApiProperty({
+    description: 'Current page number',
+    example: 1,
+  })
+  page: number;
 }

--- a/src/taxonomy/taxonomy.controller.ts
+++ b/src/taxonomy/taxonomy.controller.ts
@@ -16,6 +16,7 @@ import {
   taxonomyTermsQuerySchema,
 } from './dto/taxonomy-terms-query.dto';
 import { TaxonomySearchResponse } from './dto/taxonomy-response.dto';
+import { TaxonomyResponseDto } from './dto/taxonomy-response.dto';
 
 @ApiTags('Taxonomy')
 @Controller('taxonomy')
@@ -140,6 +141,54 @@ export class TaxonomyController {
     @Query(new ZodValidationPipe(searchQuerySchema)) query: SearchQueryDto,
   ): Promise<TaxonomySearchResponse> {
     return this.taxonomyService.searchTaxonomies({
+      headers,
+      query,
+    });
+  }
+
+  @Get()
+  @Version('2')
+  @ApiResponse({
+    status: 200,
+    description:
+      'Returns simplified taxonomy data with only id, name, and code',
+    type: TaxonomyResponseDto,
+  })
+  @ApiQuery({
+    name: 'query',
+    required: false,
+    description: 'Search query for taxonomy name or code',
+  })
+  @ApiQuery({
+    name: 'code',
+    required: false,
+    deprecated: true,
+    description: 'Taxonomy code (deprecated, use query instead)',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    schema: { default: 1 },
+    description: 'Page number for pagination',
+  })
+  @ApiHeader({ name: 'x-tenant-id', required: true })
+  @ApiHeader({
+    name: 'accept-language',
+    schema: {
+      default: 'en',
+    },
+  })
+  @ApiHeader({
+    name: 'x-api-version',
+    schema: {
+      default: '2',
+    },
+  })
+  getTaxonomiesV2(
+    @CustomHeaders(new ZodValidationPipe(headersSchema)) headers: HeadersDto,
+    @Query(new ZodValidationPipe(searchQuerySchema)) query: SearchQueryDto,
+  ): Promise<TaxonomyResponseDto> {
+    return this.taxonomyService.searchTaxonomiesV2({
       headers,
       query,
     });


### PR DESCRIPTION
## Summary
Added v2 endpoint for taxonomy search that returns a simplified response payload containing only essential fields (`id`, `name`, `code`) instead of the full Elasticsearch response.

## Changes
- Created `TaxonomyResponseDto` with streamlined structure
- Added `GET /taxonomy` v2 endpoint (set `x-api-version: 2` header)
- Reduced response size significantly by excluding metadata fields like `_index`, `_score`, `_routing`, `tenant_id`, timestamps, etc.

## Motivation
The v1 endpoint returns large Elasticsearch responses with extensive metadata that isn't needed by consumers, resulting in unnecessary bandwidth usage and slower response times.