### PR TITLE
perf: enable cdn caching for search and resource endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -30,6 +30,8 @@ import { SuggestionModule } from './suggestion/suggestion.module';
 import { SuggestionController } from './suggestion/suggestion.controller';
 import { GeocodingModule } from './geocoding/geocoding.module';
 import { CmsConfigModule } from './cms-config/cms-config.module';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { CdnCacheControlInterceptor } from './common/interceptors/cdn-cache-control.interceptor';
 
 @Module({
   imports: [
@@ -63,7 +65,10 @@ import { CmsConfigModule } from './cms-config/cms-config.module';
     GeocodingModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    { provide: APP_INTERCEPTOR, useClass: CdnCacheControlInterceptor },
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/src/common/const/fifteen-minutes.ts
+++ b/src/common/const/fifteen-minutes.ts
@@ -1,0 +1,3 @@
+import { Seconds } from '../types';
+
+export const FIFTEEN_MINUTES: Seconds = 15 * 60;

--- a/src/common/const/index.ts
+++ b/src/common/const/index.ts
@@ -1,0 +1,1 @@
+export * from './fifteen-minutes';

--- a/src/common/const/one-hour.ts
+++ b/src/common/const/one-hour.ts
@@ -1,0 +1,3 @@
+import { Seconds } from '../types';
+
+export const ONE_HOUR: Seconds = 3600;

--- a/src/common/const/one-hour.ts
+++ b/src/common/const/one-hour.ts
@@ -1,3 +1,0 @@
-import { Seconds } from '../types';
-
-export const ONE_HOUR: Seconds = 3600;

--- a/src/common/decorators/cdn-cache-ttl.decorator.ts
+++ b/src/common/decorators/cdn-cache-ttl.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+import { CDN_CACHE_TTL_KEY } from '../interceptors/cdn-cache-control.interceptor';
+import { Seconds } from '../types';
+
+export const SetCdnCacheTTL = (ttl: Seconds) =>
+  SetMetadata(CDN_CACHE_TTL_KEY, ttl);

--- a/src/common/interceptors/cdn-cache-control.interceptor.ts
+++ b/src/common/interceptors/cdn-cache-control.interceptor.ts
@@ -1,0 +1,51 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { Reflector } from '@nestjs/core';
+
+export const CDN_CACHE_TTL_KEY = 'cdn_cache_ttl';
+
+/**
+ * Interceptor to set Cache-Control headers for CDN caching
+ * Use @SetCdnCacheTTL(seconds) decorator to configure per-route
+ */
+@Injectable()
+export class CdnCacheControlInterceptor implements NestInterceptor {
+  constructor(private reflector: Reflector) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const ttl = this.reflector.get<number>(
+      CDN_CACHE_TTL_KEY,
+      context.getHandler(),
+    );
+
+    return next.handle().pipe(
+      tap(() => {
+        if (ttl !== undefined) {
+          const response = context.switchToHttp().getResponse();
+
+          if (response.statusCode === 200) {
+            response.setHeader('Vary', 'x-tenant-id, accept-language');
+
+            if (ttl === 0) {
+              response.setHeader(
+                'Cache-Control',
+                'no-store, no-cache, must-revalidate, private',
+              );
+            } else {
+              response.setHeader(
+                'Cache-Control',
+                `public, max-age=${ttl}, s-maxage=${ttl}`,
+              );
+            }
+          }
+        }
+      }),
+    );
+  }
+}

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -1,0 +1,2 @@
+export * from './locale';
+export * from './seconds';

--- a/src/common/types/seconds.ts
+++ b/src/common/types/seconds.ts
@@ -1,0 +1,1 @@
+export type Seconds = number;

--- a/src/resource/resource.controller.ts
+++ b/src/resource/resource.controller.ts
@@ -4,6 +4,8 @@ import { ApiHeader, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CustomHeaders } from 'src/common/decorators/CustomHeaders';
 import { ZodValidationPipe } from 'src/common/pipes/zod-validation-pipe';
 import { HeadersDto, headersSchema } from 'src/common/dto/headers.dto';
+import { ONE_HOUR } from 'src/common/const/one-hour';
+import { SetCdnCacheTTL } from 'src/common/decorators/cdn-cache-ttl.decorator';
 
 @ApiTags('Resource')
 @Controller('resource')
@@ -12,6 +14,7 @@ export class ResourceController {
 
   @Get(':id')
   @Version('1')
+  @SetCdnCacheTTL(ONE_HOUR)
   @ApiHeader({ name: 'accept-language', required: true })
   @ApiHeader({ name: 'x-tenant-id', required: true })
   @ApiParam({ name: 'id' })
@@ -121,6 +124,7 @@ export class ResourceController {
   }
 
   @Get('original/:id')
+  @SetCdnCacheTTL(ONE_HOUR)
   @Version('1')
   @ApiHeader({ name: 'accept-language', required: true })
   @ApiHeader({ name: 'x-tenant-id', required: true })

--- a/src/resource/resource.controller.ts
+++ b/src/resource/resource.controller.ts
@@ -4,8 +4,8 @@ import { ApiHeader, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CustomHeaders } from 'src/common/decorators/CustomHeaders';
 import { ZodValidationPipe } from 'src/common/pipes/zod-validation-pipe';
 import { HeadersDto, headersSchema } from 'src/common/dto/headers.dto';
-import { ONE_HOUR } from 'src/common/const/one-hour';
 import { SetCdnCacheTTL } from 'src/common/decorators/cdn-cache-ttl.decorator';
+import { FIFTEEN_MINUTES } from 'src/common/const';
 
 @ApiTags('Resource')
 @Controller('resource')
@@ -14,7 +14,7 @@ export class ResourceController {
 
   @Get(':id')
   @Version('1')
-  @SetCdnCacheTTL(ONE_HOUR)
+  @SetCdnCacheTTL(FIFTEEN_MINUTES)
   @ApiHeader({ name: 'accept-language', required: true })
   @ApiHeader({ name: 'x-tenant-id', required: true })
   @ApiParam({ name: 'id' })
@@ -124,7 +124,7 @@ export class ResourceController {
   }
 
   @Get('original/:id')
-  @SetCdnCacheTTL(ONE_HOUR)
+  @SetCdnCacheTTL(FIFTEEN_MINUTES)
   @Version('1')
   @ApiHeader({ name: 'accept-language', required: true })
   @ApiHeader({ name: 'x-tenant-id', required: true })

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -25,6 +25,9 @@ import { CustomHeaders } from '../common/decorators/CustomHeaders';
 import { ApiQueryForComplexSearch } from './api-query-decorator';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { SearchResponse } from './dto/search-response.dto';
+import { ONE_HOUR } from 'src/common/const/one-hour';
+import { SetCdnCacheTTL } from 'src/common/decorators/cdn-cache-ttl.decorator';
+
 @ApiTags('Search')
 @Controller('search')
 @ApiHeader({
@@ -40,6 +43,7 @@ export class SearchController {
 
   @Get()
   @Version('1')
+  @SetCdnCacheTTL(ONE_HOUR)
   @ApiResponse({
     status: 200,
     type: SearchResponseDto,
@@ -100,6 +104,7 @@ export class SearchController {
 
   @Post()
   @Version('1')
+  @SetCdnCacheTTL(ONE_HOUR)
   @ApiResponse({
     status: 200,
     description: 'Search resources (POST)',

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -104,7 +104,6 @@ export class SearchController {
 
   @Post()
   @Version('1')
-  @SetCdnCacheTTL(FIFTEEN_MINUTES)
   @ApiResponse({
     status: 200,
     description: 'Search resources (POST)',

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -25,8 +25,8 @@ import { CustomHeaders } from '../common/decorators/CustomHeaders';
 import { ApiQueryForComplexSearch } from './api-query-decorator';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { SearchResponse } from './dto/search-response.dto';
-import { ONE_HOUR } from 'src/common/const/one-hour';
 import { SetCdnCacheTTL } from 'src/common/decorators/cdn-cache-ttl.decorator';
+import { FIFTEEN_MINUTES } from 'src/common/const';
 
 @ApiTags('Search')
 @Controller('search')
@@ -43,7 +43,7 @@ export class SearchController {
 
   @Get()
   @Version('1')
-  @SetCdnCacheTTL(ONE_HOUR)
+  @SetCdnCacheTTL(FIFTEEN_MINUTES)
   @ApiResponse({
     status: 200,
     type: SearchResponseDto,
@@ -104,7 +104,7 @@ export class SearchController {
 
   @Post()
   @Version('1')
-  @SetCdnCacheTTL(ONE_HOUR)
+  @SetCdnCacheTTL(FIFTEEN_MINUTES)
   @ApiResponse({
     status: 200,
     description: 'Search resources (POST)',


### PR DESCRIPTION
## Summary

Adds HTTP cache headers to enable DigitalOcean CDN edge caching, reducing latency and API load.

## Changes

- **New interceptor** (`CdnCacheControlInterceptor`): Sets `Cache-Control` and `Vary` headers on GET requests
- **New decorator** (`@SetCdnCacheTTL(seconds)`): Per-route cache TTL configuration
- **Applied to endpoints:**
  - `GET /search` → 1 hour cache
  - `GET /resource/:id` → 1 hour cache
  - `GET /resource/original/:id` → 1 hour cache

## Headers Set

```http
Cache-Control: public, max-age=3600, s-maxage=3600
Vary: x-tenant-id, accept-language
```

## Important Notes

⚠️ **Vary Header Uncertainty**: We're not certain if DigitalOcean CDN respects the `Vary` header for cache isolation. 

**Current approach:** Using `Vary: x-tenant-id, accept-language` to create separate caches per tenant/language.

**Fallback plan:** If CDN doesn't respect `Vary`, we'll need to add tenant ID and locale to query parameters for proper cache isolation:

```
/search?query=food&tenant_id=xxx&locale=en
```

This prevents cross-tenant data leakage by making cache keys unique per tenant/language combination.
