### PR TITLE
fix favorite list auth

### DIFF
--- a/src/auth/guards/keycloak.guard.ts
+++ b/src/auth/guards/keycloak.guard.ts
@@ -1,16 +1,26 @@
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { Request } from 'express';
-import { Observable } from 'rxjs';
 import { KeycloakAuthService } from '../services/keycloak-auth.service';
 
 @Injectable()
 export class KeycloakGuard implements CanActivate {
   constructor(private readonly keycloakAuthService: KeycloakAuthService) {}
 
-  canActivate(
-    context: ExecutionContext,
-  ): boolean | Promise<boolean> | Observable<boolean> {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
-    return this.keycloakAuthService.isAuthorized(request);
+    const result = await this.keycloakAuthService.verifyToken(request);
+
+    if (!result.isAuthenticated) {
+      throw new UnauthorizedException(
+        'Authorization token is missing or invalid.',
+      );
+    }
+
+    return true;
   }
 }

--- a/src/auth/services/keycloak-auth.service.ts
+++ b/src/auth/services/keycloak-auth.service.ts
@@ -47,9 +47,12 @@ export class KeycloakAuthService {
   ) {}
 
   /**
-   * Verify if the request is authorized based on JWT token
+   * Verify JWT token from request and extract user identity
+   * Returns authentication status and userId (if authenticated)
    */
-  async isAuthorized(request: Request): Promise<boolean> {
+  async verifyToken(
+    request: Request,
+  ): Promise<{ isAuthenticated: boolean; userId: string | null }> {
     this.logger.debug('Starting authorization check...');
 
     const tenantId = request.tenantId;
@@ -66,9 +69,9 @@ export class KeycloakAuthService {
     const token = request.headers.authorization?.split(' ')[1]; // Bearer <token>
     if (!token) {
       this.logger.warn(
-        'Authorization check failed: No authorization token (JWT) found in headers.',
+        'Token verification: No authorization token (JWT) found in headers.',
       );
-      throw new UnauthorizedException('Authorization token is missing.');
+      return { isAuthenticated: false, userId: null };
     }
 
     try {
@@ -131,15 +134,17 @@ export class KeycloakAuthService {
         algorithms: ['RS256'],
       }) as jwt.JwtPayload;
 
+      const userId = String(verifiedPayload.sub);
+
       // Populate req.user with details from the verified token.
       request.user = {
-        id: verifiedPayload.sub as string,
+        id: userId,
       };
 
       this.logger.log(
-        `User token successfully verified for realm ${keycloakRealmId}. User: ${request.user.id}`,
+        `User token successfully verified for realm ${keycloakRealmId}. User: ${userId}`,
       );
-      return true;
+      return { isAuthenticated: true, userId };
     } catch (error) {
       if (
         error instanceof jwt.JsonWebTokenError ||

--- a/src/favorite-list/favorite-list.controller.ts
+++ b/src/favorite-list/favorite-list.controller.ts
@@ -26,6 +26,7 @@ import {
   FavoriteListResponseDto,
   FavoriteListDetailResponseDto,
 } from './dto/favorite-list.response.dto';
+import { KeycloakAuthService } from 'src/auth/services/keycloak-auth.service';
 
 @ApiTags('Favorite List')
 @Controller({
@@ -33,7 +34,10 @@ import {
   version: '1',
 })
 export class FavoriteListController {
-  constructor(private readonly favoriteListService: FavoriteListService) {}
+  constructor(
+    private readonly favoriteListService: FavoriteListService,
+    private readonly keycloakAuthService: KeycloakAuthService,
+  ) {}
 
   @Post()
   @UseGuards(KeycloakGuard)
@@ -73,7 +77,14 @@ export class FavoriteListController {
     const favoriteList = await this.favoriteListService.findOne(id, locale);
 
     if (favoriteList.privacy === 'PRIVATE') {
-      if (!(request.user && request.user.id === favoriteList.ownerId)) {
+      const authResult = await this.keycloakAuthService.verifyToken(request);
+
+      if (
+        !(
+          authResult.isAuthenticated &&
+          authResult.userId === favoriteList.ownerId
+        )
+      ) {
         throw new UnauthorizedException();
       }
     }


### PR DESCRIPTION
**Problem:** 
After removing `KeycloakGuard` from the `GET /favorite-list/:id` endpoint to allow public access, private list ownership checks broke because `request.user` was no longer populated.

**Solution:**
- Refactored `KeycloakAuthService.isAuthorized()` → `verifyToken()` to return `{ isAuthenticated: boolean, userId: string | null }` instead of throwing when no token is present
- Updated `findOne()` to call `verifyToken()` directly for private lists, checking both authentication and ownership
- Public lists remain accessible without authentication; private lists require valid token with matching owner ID
