### PR TITLE
feat(cms-config): expose cached tenant branding and legal endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -272,7 +272,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -799,7 +798,6 @@
       "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.19.1.tgz",
       "integrity": "sha512-+1j9NnQVOX+lbWB8LhCM7IkUmjU05Y4+BmSLfusq0msCsQb1Va+OUKFCoOXjCJqQrcgdRdQCjYYyolQ/npQALQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@elastic/transport": "^8.9.6",
         "apache-arrow": "18.x - 21.x",
@@ -998,7 +996,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
       "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1788,6 +1787,7 @@
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
       "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -1981,7 +1981,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.22.tgz",
       "integrity": "sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -2028,7 +2027,6 @@
       "integrity": "sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -2109,7 +2107,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.22.tgz",
       "integrity": "sha512-ySSq7Py/DFozzZdNDH67m/vHoeVdphDniWBnl6q5QVoXldDdrZIHLXLRMPayTDh5A95nt7jjJzmD4qpTbNQ6tA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "body-parser": "1.20.4",
         "cors": "2.8.5",
@@ -2235,7 +2232,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
       "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
@@ -2364,7 +2360,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -2456,7 +2451,6 @@
       "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.4.0.tgz",
       "integrity": "sha512-4JdVrPtF/4rCMXp6Q1h5I6YkYZrCCcqod7Wk97ZQq7K8vNGzJUryBv4eHCvqx5sJOJBrbYm9fcswe1B0TygNoA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@mole-inc/bin-wrapper": "^8.0.1",
         "@swc/counter": "^0.1.3",
@@ -2502,7 +2496,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.23"
@@ -2884,7 +2877,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3072,7 +3064,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3163,13 +3154,15 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/whatwg-url": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
       "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -3235,7 +3228,6 @@
       "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.39.0",
         "@typescript-eslint/types": "8.39.0",
@@ -3648,7 +3640,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3662,6 +3653,7 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -3696,7 +3688,6 @@
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4378,7 +4369,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4419,6 +4409,7 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
       "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=16.20.1"
       }
@@ -4483,7 +4474,6 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -4783,15 +4773,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5562,7 +5550,8 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5625,7 +5614,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5682,7 +5670,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7086,6 +7073,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz",
       "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.0",
         "cluster-key-slot": "^1.1.0",
@@ -7110,6 +7098,7 @@
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7362,7 +7351,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8172,6 +8160,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
       "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -8181,7 +8170,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -8281,7 +8269,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -8292,7 +8281,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -8458,7 +8448,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/meow": {
       "version": "9.0.0",
@@ -8685,6 +8676,7 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.15.0.tgz",
       "integrity": "sha512-ifBhQ0rRzHDzqp9jAQP6OwHSH7dbYIQjD3SbJs9YYk9AikKEettW/9s/tbSFDTpXcRbF+u1aLrhHxDFaYtZpFQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
         "bson": "^6.10.3",
@@ -8731,6 +8723,7 @@
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
       "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^14.1.0 || ^13.0.0"
@@ -8741,6 +8734,7 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.0.tgz",
       "integrity": "sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -8753,6 +8747,7 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8762,6 +8757,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
@@ -8797,6 +8793,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
       "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -8805,6 +8802,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
       "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "peer": true,
       "dependencies": {
         "debug": "4.x"
       },
@@ -9454,7 +9452,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9946,6 +9943,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -9954,6 +9952,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "peer": true,
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -9978,7 +9977,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
       "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -10263,7 +10261,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10317,7 +10314,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10585,7 +10581,8 @@
     "node_modules/sift": {
       "version": "17.1.3",
       "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
-      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "peer": true
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -10672,6 +10669,7 @@
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -10739,7 +10737,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -11459,7 +11458,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11600,7 +11598,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11901,6 +11898,7 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -11914,6 +11912,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -11924,6 +11923,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/src/cms-config/cms-config.controller.ts
+++ b/src/cms-config/cms-config.controller.ts
@@ -1,8 +1,25 @@
-import { Controller, Post, Param, HttpCode, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Query,
+  HttpCode,
+  UseGuards,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { OrchestrationConfigService } from './orchestration-config.service';
 import { TenantConfigService } from './tenant-config.service';
 import { InternalApiGuard } from '../common/guards/internal-api.guard';
-import { ApiTags, ApiResponse, ApiSecurity, ApiParam } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiResponse,
+  ApiSecurity,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { TenantBrandingConfig, TenantLegalConfig } from './types';
 
 @ApiTags('CMS Config')
 @Controller('cms-config')
@@ -47,5 +64,222 @@ export class CmsConfigController {
   async clearTenantCache(@Param('tenantId') tenantId: string): Promise<void> {
     this.orchestrationConfigService.clearCacheForTenant(tenantId);
     this.tenantConfigService.clearCacheForTenant(tenantId);
+  }
+
+  @Get('branding/:tenantId')
+  @ApiParam({
+    name: 'tenantId',
+    required: true,
+    description: 'Tenant ID to fetch branding configuration for',
+    example: 'tenant123',
+  })
+  @ApiQuery({
+    name: 'locale',
+    required: true,
+    description:
+      'Locale to fetch branding for (must be an enabled locale for the tenant)',
+    example: 'en',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Tenant branding configuration',
+    schema: {
+      type: 'object',
+      properties: {
+        tenantId: { type: 'string', example: 'tenant123' },
+        locale: { type: 'string', example: 'en' },
+        revision: { type: 'string', example: '2026-05-15T17:20:11.000Z' },
+        resolvedFrom: {
+          type: 'object',
+          properties: {
+            source: { type: 'string', example: 'payload' },
+            resourceDirectoryId: { type: 'string', example: 'abc123' },
+          },
+        },
+        brand: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', example: 'Connect211' },
+            logoUrl: {
+              type: 'string',
+              example: 'https://cdn.example.com/logo.svg',
+            },
+            heroUrl: {
+              type: 'string',
+              example: 'https://cdn.example.com/hero.png',
+            },
+            newLayoutLogoUrl: {
+              type: 'string',
+              example: 'https://cdn.example.com/logo-new.svg',
+            },
+            newLayoutHeroUrl: {
+              type: 'string',
+              example: 'https://cdn.example.com/hero-new.png',
+            },
+            faviconUrl: {
+              type: 'string',
+              example: 'https://cdn.example.com/favicon.png',
+            },
+            openGraphUrl: {
+              type: 'string',
+              example: 'https://cdn.example.com/og.png',
+            },
+            copyright: { type: 'string', example: '© 2026 Connect211' },
+          },
+        },
+        theme: {
+          type: 'object',
+          properties: {
+            newLayoutEnabled: { type: 'boolean', example: false },
+            primaryColor: { type: 'string', example: '#005191' },
+            secondaryColor: { type: 'string', example: '#FFB351' },
+            borderRadius: { type: 'string', example: '6px' },
+            headerGradient: {
+              type: 'object',
+              properties: {
+                start: { type: 'string', example: '#ffffff' },
+                end: { type: 'string', example: '#ffffff' },
+              },
+            },
+          },
+        },
+        metadata: {
+          type: 'object',
+          properties: {
+            title: { type: 'string', example: 'Connect211' },
+            description: {
+              type: 'string',
+              example: 'Local help and resources',
+            },
+          },
+        },
+        contact: {
+          type: 'object',
+          properties: {
+            phoneNumber: { type: 'string', example: '2-1-1' },
+            feedbackUrl: {
+              type: 'string',
+              example: 'https://example.211.org/feedback',
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Missing or invalid locale query parameter',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Invalid or missing internal API key',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Branding config not found for the given tenant and locale',
+  })
+  async getTenantBranding(
+    @Param('tenantId') tenantId: string,
+    @Query('locale') locale: string,
+  ): Promise<TenantBrandingConfig> {
+    if (!locale) {
+      throw new BadRequestException('locale query parameter is required');
+    }
+
+    const branding = await this.tenantConfigService.getBrandingConfig(
+      tenantId,
+      locale,
+    );
+
+    if (!branding) {
+      throw new NotFoundException(
+        `Branding config not found for tenant ${tenantId} and locale ${locale}`,
+      );
+    }
+
+    return branding;
+  }
+
+  @Get('legal/:tenantId')
+  @ApiParam({
+    name: 'tenantId',
+    required: true,
+    description: 'Tenant ID to fetch legal configuration for',
+    example: 'tenant123',
+  })
+  @ApiQuery({
+    name: 'locale',
+    required: true,
+    description:
+      'Locale to fetch legal content for (must be an enabled locale for the tenant)',
+    example: 'en',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Tenant legal page configuration',
+    schema: {
+      type: 'object',
+      properties: {
+        tenantId: { type: 'string', example: 'tenant123' },
+        locale: { type: 'string', example: 'en' },
+        revision: { type: 'string', example: '2026-05-15T17:20:11.000Z' },
+        resolvedFrom: {
+          type: 'object',
+          properties: {
+            source: { type: 'string', example: 'payload' },
+            resourceDirectoryId: { type: 'string', example: 'abc123' },
+          },
+        },
+        privacyPolicy: {
+          type: 'object',
+          properties: {
+            enabled: { type: 'boolean', example: true },
+            title: { type: 'string', example: 'Privacy Policy' },
+            content: { type: 'string', example: 'We respect your privacy...' },
+          },
+        },
+        termsOfUse: {
+          type: 'object',
+          properties: {
+            enabled: { type: 'boolean', example: true },
+            title: { type: 'string', example: 'Terms of Use' },
+            content: { type: 'string', example: 'By using this service...' },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Missing or invalid locale query parameter',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Invalid or missing internal API key',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Legal config not found for the given tenant and locale',
+  })
+  async getTenantLegal(
+    @Param('tenantId') tenantId: string,
+    @Query('locale') locale: string,
+  ): Promise<TenantLegalConfig> {
+    if (!locale) {
+      throw new BadRequestException('locale query parameter is required');
+    }
+
+    const legal = await this.tenantConfigService.getLegalConfig(
+      tenantId,
+      locale,
+    );
+
+    if (!legal) {
+      throw new NotFoundException(
+        `Legal config not found for tenant ${tenantId} and locale ${locale}`,
+      );
+    }
+
+    return legal;
   }
 }

--- a/src/cms-config/tenant-config.service.ts
+++ b/src/cms-config/tenant-config.service.ts
@@ -11,7 +11,12 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { LRUCache } from 'lru-cache';
 import qs from 'qs';
 import { CmsRedisService } from './cms-redis.service';
-import { FacetConfig, FacetsConfigCache } from './types';
+import {
+  FacetConfig,
+  FacetsConfigCache,
+  TenantBrandingConfig,
+  TenantLegalConfig,
+} from './types';
 import { LRU_CACHE_CONFIG } from './const/lru-cache-config';
 
 @Injectable()
@@ -24,6 +29,12 @@ export class TenantConfigService {
     LRU_CACHE_CONFIG,
   );
   private readonly localesCache = new LRUCache<string, string[]>(
+    LRU_CACHE_CONFIG,
+  );
+  private readonly brandingCache = new LRUCache<string, TenantBrandingConfig>(
+    LRU_CACHE_CONFIG,
+  );
+  private readonly legalCache = new LRUCache<string, TenantLegalConfig>(
     LRU_CACHE_CONFIG,
   );
 
@@ -148,6 +159,84 @@ export class TenantConfigService {
     return [];
   }
 
+  async getBrandingConfig(
+    tenantId: string,
+    locale: string,
+  ): Promise<TenantBrandingConfig | null> {
+    return this.getLocaleConfig(
+      this.brandingCache,
+      'branding_config',
+      'branding config',
+      tenantId,
+      locale,
+    );
+  }
+
+  async getLegalConfig(
+    tenantId: string,
+    locale: string,
+  ): Promise<TenantLegalConfig | null> {
+    return this.getLocaleConfig(
+      this.legalCache,
+      'legal_config',
+      'legal config',
+      tenantId,
+      locale,
+    );
+  }
+
+  private async getLocaleConfig<T>(
+    cache: LRUCache<string, T>,
+    redisKeyPrefix: string,
+    label: string,
+    tenantId: string,
+    locale: string,
+  ): Promise<T | null> {
+    this.logger.debug(
+      `Fetching ${label} for tenant: ${tenantId}, locale: ${locale}`,
+    );
+
+    const cacheKey = `${tenantId}:${locale}`;
+
+    const inMemoryCached = cache.get(cacheKey);
+    if (inMemoryCached) {
+      this.logger.debug(
+        `In-memory cache hit for ${label}: ${tenantId}/${locale}`,
+      );
+      return inMemoryCached;
+    }
+
+    try {
+      const redisKey = `${redisKeyPrefix}:${tenantId}:${locale}`;
+      const redisValue = await this.cmsRedisService.get(redisKey);
+
+      if (redisValue && typeof redisValue === 'string') {
+        this.logger.debug(`Redis DB 2 hit for ${label}: ${tenantId}/${locale}`);
+        const parsed = JSON.parse(redisValue) as T;
+        cache.set(cacheKey, parsed);
+        return parsed;
+      }
+    } catch (error) {
+      this.logger.error(
+        `Error fetching ${label} from Redis DB 2 for ${tenantId}/${locale}: ${error.message}`,
+      );
+    }
+
+    this.logger.warn(
+      `No ${label} found for tenant: ${tenantId}, locale: ${locale}`,
+    );
+    return null;
+  }
+
+  private evictByTenantPrefix<T>(
+    cache: LRUCache<string, T>,
+    tenantId: string,
+  ): void {
+    for (const key of cache.keys()) {
+      if (key.startsWith(`${tenantId}:`)) cache.delete(key);
+    }
+  }
+
   /**
    *
    * @deprecated This method is only used as a fallback to fetch tenant configuration from Strapi when Redis DB 2 is unavailable or missing data.
@@ -223,6 +312,8 @@ export class TenantConfigService {
     this.keycloakRealmIdCache.clear();
     this.facetsCache.clear();
     this.localesCache.clear();
+    this.brandingCache.clear();
+    this.legalCache.clear();
     this.logger.log('All in-memory cache cleared');
   }
 
@@ -231,6 +322,9 @@ export class TenantConfigService {
     this.keycloakRealmIdCache.delete(tenantId);
     this.facetsCache.delete(tenantId);
     this.localesCache.delete(tenantId);
+    // branding and legal caches are keyed by tenantId:locale — purge all entries for this tenant
+    this.evictByTenantPrefix(this.brandingCache, tenantId);
+    this.evictByTenantPrefix(this.legalCache, tenantId);
     this.logger.log(`In-memory cache cleared for tenant: ${tenantId}`);
   }
 }

--- a/src/cms-config/types/branding-config.ts
+++ b/src/cms-config/types/branding-config.ts
@@ -1,0 +1,46 @@
+export type BrandingConfigResolvedFrom = {
+  source: 'payload';
+  resourceDirectoryId: string;
+};
+
+export type BrandingConfigTheme = {
+  /** Whether the newLayout chrome (gradient header, alternate logo) is active for this tenant. */
+  newLayoutEnabled: boolean;
+  primaryColor: string;
+  secondaryColor: string;
+  borderRadius: string;
+  headerGradient: {
+    start: string;
+    end: string;
+  };
+};
+
+export type TenantBrandingConfig = {
+  tenantId: string;
+  locale: string;
+  revision: string;
+  resolvedFrom: BrandingConfigResolvedFrom;
+  brand: {
+    name: string;
+    /** Primary brand logo (brand tab). */
+    logoUrl?: string;
+    /** Brand tab hero image. */
+    heroUrl?: string;
+    /** Alternate logo shown when newLayout is enabled (newLayout tab). */
+    newLayoutLogoUrl?: string;
+    /** New layout hero image. */
+    newLayoutHeroUrl?: string;
+    faviconUrl?: string;
+    openGraphUrl?: string;
+    copyright?: string;
+  };
+  theme: BrandingConfigTheme;
+  metadata: {
+    title?: string;
+    description?: string;
+  };
+  contact: {
+    phoneNumber?: string;
+    feedbackUrl?: string;
+  };
+};

--- a/src/cms-config/types/index.ts
+++ b/src/cms-config/types/index.ts
@@ -1,5 +1,7 @@
+export * from './branding-config';
 export * from './custom-attribute';
 export * from './facet-config';
 export * from './facets-config-cache';
+export * from './legal-config';
 export * from './orchestration-config-cache';
 export * from './schema-config';

--- a/src/cms-config/types/legal-config.ts
+++ b/src/cms-config/types/legal-config.ts
@@ -1,0 +1,19 @@
+export type LegalPage = {
+  enabled: boolean;
+  title?: string;
+  content?: string;
+};
+
+export type LegalConfigResolvedFrom = {
+  source: 'payload';
+  resourceDirectoryId: string;
+};
+
+export type TenantLegalConfig = {
+  tenantId: string;
+  locale: string;
+  revision: string;
+  resolvedFrom: LegalConfigResolvedFrom;
+  privacyPolicy: LegalPage;
+  termsOfUse: LegalPage;
+};


### PR DESCRIPTION
## Summary
- add internal CMS config endpoints for tenant branding and legal content by locale
- read branding and legal snapshots from Redis with in-memory caching and tenant-level cache invalidation
- document the new response shapes so consumers can fetch asset URLs, privacy policy content, and terms of use content consistently

## Why
This is the API half of the CMS config work. It exposes the cached tenant branding and legal configuration through stable internal endpoints for downstream consumers.